### PR TITLE
Fixing case sensitive of table names, would not work on mysql installs w...

### DIFF
--- a/spring-nanotrader-data/src/main/java/org/springframework/nanotrader/data/domain/Accountprofile.java
+++ b/spring-nanotrader-data/src/main/java/org/springframework/nanotrader/data/domain/Accountprofile.java
@@ -29,7 +29,7 @@ import javax.validation.constraints.NotNull;
 
 @SuppressWarnings("serial")
 @Entity
-@Table(name = "accountprofile")
+@Table(name = "ACCOUNTPROFILE")
 public class Accountprofile implements Serializable {
 	@Id
     @GeneratedValue(strategy = GenerationType.TABLE)

--- a/spring-nanotrader-data/src/main/java/org/springframework/nanotrader/data/domain/Holding.java
+++ b/spring-nanotrader-data/src/main/java/org/springframework/nanotrader/data/domain/Holding.java
@@ -35,7 +35,7 @@ import org.springframework.format.annotation.DateTimeFormat;
 
 @SuppressWarnings("serial")
 @Entity
-@Table(name = "holding")
+@Table(name = "HOLDING")
 public class Holding implements Serializable {
 	@Id
     @GeneratedValue(strategy = GenerationType.TABLE) 

--- a/spring-nanotrader-data/src/main/java/org/springframework/nanotrader/data/domain/Order.java
+++ b/spring-nanotrader-data/src/main/java/org/springframework/nanotrader/data/domain/Order.java
@@ -35,7 +35,7 @@ import org.springframework.format.annotation.DateTimeFormat;
 
 @SuppressWarnings("serial")
 @Entity
-@Table(name = "orders")
+@Table(name = "ORDERS")
 @org.hibernate.annotations.Entity(dynamicUpdate=true)
 public class Order implements Serializable {
 	@Id

--- a/spring-nanotrader-data/src/main/java/org/springframework/nanotrader/data/domain/Quote.java
+++ b/spring-nanotrader-data/src/main/java/org/springframework/nanotrader/data/domain/Quote.java
@@ -28,7 +28,7 @@ import javax.validation.constraints.NotNull;
 
 @SuppressWarnings("serial")
 @Entity
-@Table(name = "quote")
+@Table(name = "QUOTE")
 public class Quote implements Serializable {
 	@Id
     @GeneratedValue(strategy = GenerationType.TABLE)


### PR DESCRIPTION
The application would not run on our PCF environment. It seems that mysql on PCF is not configured to support case insensitive queries. (ClearDB is ok, they probably set lower_case_table_names=1 on mysqld)

The schema update would fail upon starting complaining about a table "QUOTE" not found. checking mysql:
+---------------------------------------------------+
| Tables_in_cf_ce77e8ca_9550_4acf_a403_4ab4c7ddd30c |
+---------------------------------------------------+
| ACCOUNT                                           |
| accountprofile                                    |
| hibernate_sequences                               |
| holding                                           |
| orders                                            |
| quote                                             |
+---------------------------------------------------+

So all tables but one were lowercase. But the insert scripts were in uppercase. Decided to update pojos to be all on upper case.

It runs fine on PCF and PWS now
